### PR TITLE
fix heading punctuation rule

### DIFF
--- a/Microsoft/HeadingPunctuation.yml
+++ b/Microsoft/HeadingPunctuation.yml
@@ -1,8 +1,8 @@
 extends: existence
-message: "Don’t use punctuation in headings."
+message: "Don’t use end punctuation in headings."
 link: https://docs.microsoft.com/en-us/style-guide/punctuation/periods
 nonword: true
 level: warning
 scope: heading
 tokens:
-  - '\w+[.?!-]'
+  - '\w+[.?!-]$'

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -131,7 +131,7 @@ Feature: Rules
       """
       test.md:1:7:Microsoft.HeadingColons:Capitalize ': m'."
       test.md:5:3:Microsoft.Headings:'This is a Heading' should use sentence-style capitalization.
-      test.md:7:11:Microsoft.HeadingPunctuation:Don’t use punctuation in headings.
+      test.md:7:11:Microsoft.HeadingPunctuation:Don’t use end punctuation in headings.
       test.md:9:15:Microsoft.HeadingAcronyms:Avoid using acronyms in a title or heading.
       """
 


### PR DESCRIPTION
The referenced MS style guide page says not to use _end punctuation_ in headings. This regex change fixes the rule to match.