### PR TITLE
Fix puntuation check

### DIFF
--- a/Microsoft/HeadingPunctuation.yml
+++ b/Microsoft/HeadingPunctuation.yml
@@ -5,4 +5,4 @@ nonword: true
 level: warning
 scope: heading
 tokens:
-  - '\w+[.?!-]$'
+  - '\s(\w+[.?!])$'


### PR DESCRIPTION
Only check punctuation at the end of the heading.

Resolves false positives headings like:
- `Release notes version 2.3.4`