### PR TITLE
Update ComplexWords.yml

### DIFF
--- a/Microsoft/ComplexWords.yml
+++ b/Microsoft/ComplexWords.yml
@@ -107,7 +107,6 @@ swap:
   provide: "'give' or 'offer'"
   purchase: "'buy'"
   relocate: "'move'"
-  request: "'ask'"
   solicit: "'request'"
   state-of-the-art: "'latest'"
   subsequent: "'later' or 'next'"


### PR DESCRIPTION
https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/a/ask states "Don't use as a noun. Use request, task, or another suitable word."

This also has a conflict with microsoft.Avoid - which says "don't use ask". So if you put in 'request' it says "use ask" but if you put in "ask" it says "don't use ask".

(Hope I did this correctly!)