### PR TITLE
Add 'or' to OxfordComma regex

### DIFF
--- a/Microsoft/OxfordComma.yml
+++ b/Microsoft/OxfordComma.yml
@@ -4,4 +4,4 @@ link: https://docs.microsoft.com/en-us/style-guide/punctuation/commas
 scope: sentence
 level: warning
 tokens:
-  - '(?:[^,]+,){1,}\s\w+\sand'
+  - '(?:[^,]+,){1,}\s\w+\s(and|or)'

--- a/Microsoft/OxfordComma.yml
+++ b/Microsoft/OxfordComma.yml
@@ -4,4 +4,4 @@ link: https://docs.microsoft.com/en-us/style-guide/punctuation/commas
 scope: sentence
 level: warning
 tokens:
-  - '(?:[^,]+,){1,}\s\w+\s(and|or)'
+  - '(?:[^,]+,){1,}\s\w+\s(?:and|or)'


### PR DESCRIPTION
In the examples in https://docs.microsoft.com/en-us/style-guide/punctuation/commas, the style guide explicitly mentions "and" and "or" as conjunctions requiring a serial comma. This pull request adds support for detecting "or" to the regex.