### PR TITLE
Fix regex and update message for Avoid rule

### DIFF
--- a/Microsoft/Avoid.yml
+++ b/Microsoft/Avoid.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Don't use '%s'."
+message: "Don't use '%s'. See the A-Z word list for details."
 # See the A-Z word list
 link: https://docs.microsoft.com/en-us/style-guide
 ignorecase: true
@@ -7,7 +7,7 @@ level: error
 tokens:
   - abortion
   - and so on
-  - app(?:lication)s? (?:developer|program)
+  - app(?:lication)?s? (?:developer|program)
   - app(?:lication)? file
   - backbone
   - backend


### PR DESCRIPTION
- Adds correct quantifier for app(lication)(s) developer token
    - At present, _app(s) developer_ is not caught
- Adds A-Z list direction to message
    - Provides clarification on why not to use these words, and substitutes