### PR TITLE
Only correct "they are" if it isn't at the end of a sentence

### DIFF
--- a/Microsoft/Contractions.yml
+++ b/Microsoft/Contractions.yml
@@ -19,7 +19,7 @@ swap:
   it is: it's
   should not: shouldn't
   that is: that's
-  they are: they're
+  'they are(?!\.)': they're
   was not: wasn't
   we are: we're
   we have: we've

--- a/Microsoft/Contractions.yml
+++ b/Microsoft/Contractions.yml
@@ -16,15 +16,15 @@ swap:
   have not: haven't
   how is: how's
   is not: isn't
-  it is: it's
+  'it is(?!\.)': it's
   should not: shouldn't
-  that is: that's
+  'that is(?!\.)': that's
   'they are(?!\.)': they're
   was not: wasn't
-  we are: we're
-  we have: we've
+  'we are(?!\.)': we're
+  'we have(?!\.)': we've
   were not: weren't
-  what is: what's
+  'what is(?!\.)': what's
   when is: when's
   where is: where's
   will not: won't

--- a/Microsoft/Contractions.yml
+++ b/Microsoft/Contractions.yml
@@ -16,13 +16,19 @@ swap:
   have not: haven't
   how is: how's
   is not: isn't
+  'isn''t(?:\.)': is not
   'it is(?!\.)': it's
+  'it''s(?:\.)': it is
   should not: shouldn't
   'that is(?!\.)': that's
+  'that''s(?:\.)': that is
   'they are(?!\.)': they're
+  'they''re(?:\.)': they are
   was not: wasn't
   'we are(?!\.)': we're
+  'we''re(?:\.)': we are
   'we have(?!\.)': we've
+  'we''ve(?:\.)': we have
   were not: weren't
   'what is(?!\.)': what's
   when is: when's

--- a/Microsoft/Contractions.yml
+++ b/Microsoft/Contractions.yml
@@ -16,19 +16,19 @@ swap:
   have not: haven't
   how is: how's
   is not: isn't
-  'isn''t(?:\.)': is not
+  'isn''t(?=\.)': is not
   'it is(?!\.)': it's
-  'it''s(?:\.)': it is
+  'it''s(?=\.)': it is
   should not: shouldn't
   'that is(?!\.)': that's
-  'that''s(?:\.)': that is
+  'that''s(?=\.)': that is
   'they are(?!\.)': they're
-  'they''re(?:\.)': they are
+  'they''re(?=\.)': they are
   was not: wasn't
   'we are(?!\.)': we're
-  'we''re(?:\.)': we are
+  'we''re(?=\.)': we are
   'we have(?!\.)': we've
-  'we''ve(?:\.)': we have
+  'we''ve(?=\.)': we have
   were not: weren't
   'what is(?!\.)': what's
   when is: when's

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -1,14 +1,75 @@
 # Contractions
 
-<!-- Should fail -->
-It is cold outside.
-
-<!-- Should pass -->
-We welcome all contributions, no matter how great or small they are.
-It can reach anyone, wherever they are.
-It can reach anyone, wherever they're located.
-They're a great team.
-
-<!-- Should fail -->
-It can reach anyone, wherever they are located.
-They are a great team.
+<!-- are not: aren't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- cannot: can't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- could not: couldn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- did not: didn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- do not: don't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- does not: doesn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- has not: hasn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- have not: haven't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- how is: how's -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- is not: isn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- it is: it's -->
+  <!-- Should pass -->
+  It's cold outside.
+  <!-- Should fail -->
+  It is cold outside.
+<!-- should not: shouldn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- that is: that's -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- they are: they're -->
+  <!-- Should pass -->
+  It can reach anyone, wherever they are.
+  It can reach anyone, wherever they're located.
+  They're a great team.
+  <!-- Should fail -->
+  It can reach anyone, wherever they are located.
+  They are a great team.
+<!-- was not: wasn't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- we are: we're -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- we have: we've -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- were not: weren't -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- what is: what's -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- when is: when's -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- where is: where's -->
+  <!-- Should pass -->
+  <!-- Should fail -->
+<!-- will not: won't -->
+  <!-- Should pass -->
+  <!-- Should fail -->

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -35,7 +35,7 @@
   <!-- Should fail -->
   Did not we do something about it?
   We did not do something about it.
-  Unfortunately, it didn't.
+  Unfortunately, it didn't. <!-- TODO -->
 <!-- don't -->
   <!-- Should pass -->
   Don't you want to win?
@@ -81,7 +81,7 @@
   <!-- Should pass -->
   Isn't that amazing?
   That isn't possible.
-  I can't tell what is and what isn't.
+  I can't tell what is and what isn't. <!-- TODO -->
   <!-- Should fail -->
   Is not that amazing?
   That is not possible.
@@ -90,11 +90,11 @@
   <!-- Should pass -->
   It's cold outside.
   I think it's cold outside.
-  Let's find it, wherever it is.
+  Let's find it, wherever it is. <!-- TODO -->
   <!-- Should fail -->
   It is cold outside.
   I think it is cold outside.
-  Let's find it, wherever it's.
+  Let's find it, wherever it's. <!-- TODO -->
 <!-- shouldn't -->
   <!-- Should pass -->
   Shouldn't you be going?
@@ -108,18 +108,18 @@
   <!-- Should pass -->
   That's amazing.
   All that's here is free.
-  He wouldn't lie - if he could help it, that is.
+  He wouldn't lie - if he could help it, that is. <!-- TODO -->
   <!-- Should fail -->
   That is amazing.
   All that is here is free.
-  He wouldn't lie - if he could help it, that's.
+  He wouldn't lie - if he could help it, that's. <!-- TODO -->
 <!-- they're -->
   <!-- Should pass -->
   It can reach anyone, wherever they are.
   It can reach anyone, wherever they're located.
   They're a great team.
   <!-- Should fail -->
-  It can reach anyone, wherever they're.
+  It can reach anyone, wherever they're. <!-- TODO -->
   It can reach anyone, wherever they are located.
   They are a great team.
 <!-- wasn't -->
@@ -135,16 +135,16 @@
   <!-- Should pass -->
   We're groove crusaders.
   I think we're a great team.
-  Nobody knows where we are.
+  Nobody knows where we are. <!-- TODO -->
   <!-- Should fail -->
   We are groove crusaders.
   I think we are a great team.
-  Nobody knows where we're.
+  Nobody knows where we're. <!-- TODO -->
 <!-- we've -->
   <!-- Should pass -->
   We've come so far.
   Let's think about what we've done.
-  We should be grateful for all that we have.
+  We should be grateful for all that we have. <!-- TODO -->
   <!-- Should fail -->
   We have come so far.
   Let's think about what we have done.

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -1,6 +1,6 @@
 # Contractions
 
-<!-- are not: aren't -->
+<!-- aren't -->
   <!-- Should pass -->
   Aren't you tired?
   They aren't ready yet.
@@ -9,7 +9,7 @@
   Are not you tired?
   They are not ready yet.
   I'll prepare those that are not.
-<!-- cannot: can't -->
+<!-- can't -->
   <!-- Should pass -->
   Can't we do something about it?
   We can't do something about it.
@@ -18,7 +18,7 @@
   Cannot we do something about it?
   We cannot do something about it.
   We've tried, and we really cannot.
-<!-- could not: couldn't -->
+<!-- couldn't -->
   <!-- Should pass -->
   Couldn't we do something about it?
   We couldn't do something about it.
@@ -27,7 +27,7 @@
   Could not we do something about it?
   We could not do something about it.
   We've tried, and we really could not.
-<!-- did not: didn't -->
+<!-- didn't -->
   <!-- Should pass -->
   Didn't we do something about it?
   We didn't do something about it.
@@ -36,7 +36,7 @@
   Did not we do something about it?
   We did not do something about it.
   Unfortunately, it didn't.
-<!-- do not: don't -->
+<!-- don't -->
   <!-- Should pass -->
   Don't you want to win?
   I don't think I can do this.
@@ -45,7 +45,7 @@
   Do not you want to win?
   I do not think I can do this.
   Please do not.
-<!-- does not: doesn't -->
+<!-- doesn't -->
   <!-- Should pass -->
   Doesn't that sound great?
   That doesn't sound great...
@@ -54,7 +54,7 @@
   Does not that sound great?
   That does not sound great...
   You might think it does, but it does not.
-<!-- has not: hasn't -->
+<!-- hasn't -->
   <!-- Should pass -->
   Hasn't it been great?
   That hasn't changed.
@@ -63,7 +63,7 @@
   Has not that sound great?
   That has not changed
   You might think it has, but it has not.
-<!-- have not: haven't -->
+<!-- haven't -->
   <!-- Should pass -->
   Haven't you had a great time?
   I haven't been here for a while.
@@ -72,12 +72,12 @@
   Have not you had a great time?
   I have not been here for a while.
   I have not.
-<!-- how is: how's -->
+<!-- how's -->
   <!-- Should pass -->
   How's everyone back home?
   <!-- Should fail -->
   How is everyone back home?
-<!-- is not: isn't -->
+<!-- isn't -->
   <!-- Should pass -->
   Isn't that amazing?
   That isn't possible.
@@ -86,7 +86,7 @@
   Is not that amazing?
   That is not possible.
   I can't tell what is and what is not.
-<!-- it is: it's -->
+<!-- it's -->
   <!-- Should pass -->
   It's cold outside.
   I think it's cold outside.
@@ -95,7 +95,7 @@
   It is cold outside.
   I think it is cold outside.
   Let's find it, wherever it's.
-<!-- should not: shouldn't -->
+<!-- shouldn't -->
   <!-- Should pass -->
   Shouldn't you be going?
   You shouldn't go anywhere.
@@ -104,7 +104,7 @@
   Should not you be going?
   You should not go anywhere.
   Maybe you really should not.
-<!-- that is: that's -->
+<!-- that's -->
   <!-- Should pass -->
   That's amazing.
   All that's here is free.
@@ -113,7 +113,7 @@
   That is amazing.
   All that is here is free.
   He wouldn't lie - if he could help it, that's.
-<!-- they are: they're -->
+<!-- they're -->
   <!-- Should pass -->
   It can reach anyone, wherever they are.
   It can reach anyone, wherever they're located.
@@ -122,7 +122,7 @@
   It can reach anyone, wherever they're.
   It can reach anyone, wherever they are located.
   They are a great team.
-<!-- was not: wasn't -->
+<!-- wasn't -->
   <!-- Should pass -->
   Wasn't that amazing?
   It wasn't great.
@@ -131,7 +131,7 @@
   Was not that amazing?
   It was not great.
   It was not.
-<!-- we are: we're -->
+<!-- we're -->
   <!-- Should pass -->
   We're groove crusaders.
   I think we're a great team.
@@ -140,7 +140,7 @@
   We are groove crusaders.
   I think we are a great team.
   Nobody knows where we're.
-<!-- we have: we've -->
+<!-- we've -->
   <!-- Should pass -->
   We've come so far.
   Let's think about what we've done.
@@ -149,7 +149,7 @@
   We have come so far.
   Let's think about what we have done.
   We should be grateful for all that we've.
-<!-- were not: weren't -->
+<!-- weren't -->
   <!-- Should pass -->
   Weren't they here last time?
   Maybe you weren't thinking straight.
@@ -158,28 +158,28 @@
   Were not they here last time?
   Maybe you were not thinking straight.
   They were not.
-<!-- what is: what's -->
+<!-- what's -->
   <!-- Should pass -->
   What's going on?
   We should do what's right.
   <!-- Should fail -->
   What is going on?
   We should do what is right.
-<!-- when is: when's -->
+<!-- when's -->
   <!-- Should pass -->
   When's it starting?
   I can't tell when's right.
   <!-- Should fail -->
   When is it starting?
   I can't tell when is right.
-<!-- where is: where's -->
+<!-- where's -->
   <!-- Should pass -->
   Where's your curly mustache at?
   I can't tell where's best.
   <!-- Should fail -->
   Where is your curly mustache at?
   I can't tell where is best.
-<!-- will not: won't -->
+<!-- won't -->
   <!-- Should pass -->
   Won't you join us?
   You won't regret it.

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -119,7 +119,7 @@
   It can reach anyone, wherever they're located.
   They're a great team.
   <!-- Should fail -->
-  It can reach anyone, wherever they're. <!-- TODO -->
+  It can reach anyone, wherever they're.
   It can reach anyone, wherever they are located.
   They are a great team.
 <!-- wasn't -->

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -2,74 +2,189 @@
 
 <!-- are not: aren't -->
   <!-- Should pass -->
+  Aren't you tired?
+  They aren't ready yet.
+  I'll prepare those that aren't.
   <!-- Should fail -->
+  Are not you tired?
+  They are not ready yet.
+  I'll prepare those that are not.
 <!-- cannot: can't -->
   <!-- Should pass -->
+  Can't we do something about it?
+  We can't do something about it.
+  We've tried, and we really can't.
   <!-- Should fail -->
+  Cannot we do something about it?
+  We cannot do something about it.
+  We've tried, and we really cannot.
 <!-- could not: couldn't -->
   <!-- Should pass -->
+  Couldn't we do something about it?
+  We couldn't do something about it.
+  We've tried, and we really couldn't.
   <!-- Should fail -->
+  Could not we do something about it?
+  We could not do something about it.
+  We've tried, and we really could not.
 <!-- did not: didn't -->
   <!-- Should pass -->
+  Didn't we do something about it?
+  We didn't do something about it.
+  Unfortunately, it didn't.
   <!-- Should fail -->
+  Did not we do something about it?
+  We did not do something about it.
+  Unfortunately, it didn't.
 <!-- do not: don't -->
   <!-- Should pass -->
+  Don't you want to win?
+  I don't think I can do this.
+  Please don't.
   <!-- Should fail -->
+  Do not you want to win?
+  I do not think I can do this.
+  Please do not.
 <!-- does not: doesn't -->
   <!-- Should pass -->
+  Doesn't that sound great?
+  That doesn't sound great...
+  You might think it does, but it doesn't.
   <!-- Should fail -->
+  Does not that sound great?
+  That does not sound great...
+  You might think it does, but it does not.
 <!-- has not: hasn't -->
   <!-- Should pass -->
+  Hasn't it been great?
+  That hasn't changed.
+  You might think it has, but it hasn't.
   <!-- Should fail -->
+  Has not that sound great?
+  That has not changed
+  You might think it has, but it has not.
 <!-- have not: haven't -->
   <!-- Should pass -->
+  Haven't you had a great time?
+  I haven't been here for a while.
+  I haven't.
   <!-- Should fail -->
+  Have not you had a great time?
+  I have not been here for a while.
+  I have not.
 <!-- how is: how's -->
   <!-- Should pass -->
+  How's everyone back home?
   <!-- Should fail -->
+  How is everyone back home?
 <!-- is not: isn't -->
   <!-- Should pass -->
+  Isn't that amazing?
+  That isn't possible.
+  I can't tell what is and what isn't.
   <!-- Should fail -->
+  Is not that amazing?
+  That is not possible.
+  I can't tell what is and what is not.
 <!-- it is: it's -->
   <!-- Should pass -->
   It's cold outside.
+  I think it's cold outside.
+  Let's find it, wherever it is.
   <!-- Should fail -->
   It is cold outside.
+  I think it is cold outside.
+  Let's find it, wherever it's.
 <!-- should not: shouldn't -->
   <!-- Should pass -->
+  Shouldn't you be going?
+  You shouldn't go anywhere.
+  Maybe you really shouldn't.
   <!-- Should fail -->
+  Should not you be going?
+  You should not go anywhere.
+  Maybe you really should not.
 <!-- that is: that's -->
   <!-- Should pass -->
+  That's amazing.
+  All that's here is free.
+  He wouldn't lie - if he could help it, that is.
   <!-- Should fail -->
+  That is amazing.
+  All that is here is free.
+  He wouldn't lie - if he could help it, that's.
 <!-- they are: they're -->
   <!-- Should pass -->
   It can reach anyone, wherever they are.
   It can reach anyone, wherever they're located.
   They're a great team.
   <!-- Should fail -->
+  It can reach anyone, wherever they're.
   It can reach anyone, wherever they are located.
   They are a great team.
 <!-- was not: wasn't -->
   <!-- Should pass -->
+  Wasn't that amazing?
+  It wasn't great.
+  It wasn't.
   <!-- Should fail -->
+  Was not that amazing?
+  It was not great.
+  It was not.
 <!-- we are: we're -->
   <!-- Should pass -->
+  We're groove crusaders.
+  I think we're a great team.
+  Nobody knows where we are.
   <!-- Should fail -->
+  We are groove crusaders.
+  I think we are a great team.
+  Nobody knows where we're.
 <!-- we have: we've -->
   <!-- Should pass -->
+  We've come so far.
+  Let's think about what we've done.
+  We should be grateful for all that we have.
   <!-- Should fail -->
+  We have come so far.
+  Let's think about what we have done.
+  We should be grateful for all that we've.
 <!-- were not: weren't -->
   <!-- Should pass -->
+  Weren't they here last time?
+  Maybe you weren't thinking straight.
+  They weren't.
   <!-- Should fail -->
+  Were not they here last time?
+  Maybe you were not thinking straight.
+  They were not.
 <!-- what is: what's -->
   <!-- Should pass -->
+  What's going on?
+  We should do what's right.
   <!-- Should fail -->
+  What is going on?
+  We should do what is right.
 <!-- when is: when's -->
   <!-- Should pass -->
+  When's it starting?
+  I can't tell when's right.
   <!-- Should fail -->
+  When is it starting?
+  I can't tell when is right.
 <!-- where is: where's -->
   <!-- Should pass -->
+  Where's your curly mustache at?
+  I can't tell where's best.
   <!-- Should fail -->
+  Where is your curly mustache at?
+  I can't tell where is best.
 <!-- will not: won't -->
   <!-- Should pass -->
+  Won't you join us?
+  You won't regret it.
+  I won't.
   <!-- Should fail -->
+  Will not you join us?
+  You will not regret it.
+  I will not.

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -1,3 +1,15 @@
 # Contractions
 
 It is cold outside.
+
+<!-- Should pass -->
+We welcome all contributions, no matter how great or small they are.
+It can reach anyone, wherever they are.
+It can reach anyone, wherever they're located.
+They're a great team.
+
+<!-- Should fail -->
+We welcome all contributions, no matter how great or small they're.
+It can reach anyone, wherever they're.
+It can reach anyone, wherever they are located.
+They are a great team.

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -35,7 +35,7 @@
   <!-- Should fail -->
   Did not we do something about it?
   We did not do something about it.
-  Unfortunately, it didn't. <!-- TODO -->
+  Unfortunately, it did not.
 <!-- don't -->
   <!-- Should pass -->
   Don't you want to win?
@@ -90,7 +90,7 @@
   <!-- Should pass -->
   It's cold outside.
   I think it's cold outside.
-  Let's find it, wherever it is. <!-- TODO -->
+  Let's find it, wherever it is.
   <!-- Should fail -->
   It is cold outside.
   I think it is cold outside.
@@ -108,7 +108,7 @@
   <!-- Should pass -->
   That's amazing.
   All that's here is free.
-  He wouldn't lie - if he could help it, that is. <!-- TODO -->
+  He wouldn't lie - if he could help it, that is.
   <!-- Should fail -->
   That is amazing.
   All that is here is free.
@@ -135,7 +135,7 @@
   <!-- Should pass -->
   We're groove crusaders.
   I think we're a great team.
-  Nobody knows where we are. <!-- TODO -->
+  Nobody knows where we are.
   <!-- Should fail -->
   We are groove crusaders.
   I think we are a great team.
@@ -144,11 +144,11 @@
   <!-- Should pass -->
   We've come so far.
   Let's think about what we've done.
-  We should be grateful for all that we have. <!-- TODO -->
+  We should be grateful for all that we have.
   <!-- Should fail -->
   We have come so far.
   Let's think about what we have done.
-  We should be grateful for all that we've.
+  We should be grateful for all that we've. <!-- TODO -->
 <!-- weren't -->
   <!-- Should pass -->
   Weren't they here last time?

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -162,23 +162,29 @@
   <!-- Should pass -->
   What's going on?
   We should do what's right.
+  It's easier to tell what's not there than what is.
   <!-- Should fail -->
   What is going on?
   We should do what is right.
+  It's easier to tell what's not there than what's.
 <!-- when's -->
   <!-- Should pass -->
   When's it starting?
   I can't tell when's right.
+  It's easier to figure out when's not feasible than when is.
   <!-- Should fail -->
   When is it starting?
   I can't tell when is right.
+  It's easier to figure out when's not feasible than when's.
 <!-- where's -->
   <!-- Should pass -->
   Where's your curly mustache at?
   I can't tell where's best.
+  It's easier to figure out where's not feasible than where is.
   <!-- Should fail -->
   Where is your curly mustache at?
   I can't tell where is best.
+  It's easier to figure out where's not feasible than where's.
 <!-- won't -->
   <!-- Should pass -->
   Won't you join us?

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -81,11 +81,11 @@
   <!-- Should pass -->
   Isn't that amazing?
   That isn't possible.
-  I can't tell what is and what isn't. <!-- TODO -->
+  It really isn't.
   <!-- Should fail -->
   Is not that amazing?
   That is not possible.
-  I can't tell what is and what is not.
+  It really is not.
 <!-- it's -->
   <!-- Should pass -->
   It's cold outside.

--- a/fixtures/Contractions/test.md
+++ b/fixtures/Contractions/test.md
@@ -1,5 +1,6 @@
 # Contractions
 
+<!-- Should fail -->
 It is cold outside.
 
 <!-- Should pass -->
@@ -9,7 +10,5 @@ It can reach anyone, wherever they're located.
 They're a great team.
 
 <!-- Should fail -->
-We welcome all contributions, no matter how great or small they're.
-It can reach anyone, wherever they're.
 It can reach anyone, wherever they are located.
 They are a great team.


### PR DESCRIPTION
[Thanks to @Spone for this.](https://github.com/github/view_component/issues/1213#issuecomment-1039275922)

In a sentence like "We appreciate all contributions, no matter how small they are.", Vale (backed by this repo) would suggest replacing `they are` with `they're`, resulting in the slightly awkward "no matter how small they're." This PR aims to fix that with a negative lookahead that ensures "they are" isn't followed by a period marking the end of the sentence.

Do we also want to include other symbols that can end sentences (`?` `!`) in the regex?