### PR TITLE
Remove 'nonword' property from FirstPerson.yml

### DIFF
--- a/Microsoft/FirstPerson.yml
+++ b/Microsoft/FirstPerson.yml
@@ -3,7 +3,6 @@ message: "Use first person (such as '%s') sparingly."
 link: https://docs.microsoft.com/en-us/style-guide/grammar/person
 ignorecase: true
 level: warning
-nonword: true
 tokens:
   - (?:^|\s)I(?=\s)
   - (?:^|\s)I(?=,\s)


### PR DESCRIPTION
I am not sure if this has any effect on anything else, but this property seems to cause issues with the underlines in extensions that use the language server, removing it fixes that.

If you feel it's needed, I'll try and find another solution.